### PR TITLE
SVG output with real text, not glyphs

### DIFF
--- a/server.R
+++ b/server.R
@@ -6,6 +6,7 @@ library(gridExtra)
 library(plyr)
 library(UpSetR)
 library(shinythemes)
+library(RSVGTipsDevice)
 source("converters.R")
 
 shinyServer(function(input, output, session){
@@ -445,7 +446,7 @@ My_data <- reactive({
         png(file, width=width*pixelratio, height=height*pixelratio,
             res=72*pixelratio)
       else if(input$filetype == "svg")
-          svg(file)
+          devSVGTips(file)
       else
         pdf(file,width = 22, height = 14)
       upset(data = My_data(), 

--- a/server.R
+++ b/server.R
@@ -446,7 +446,7 @@ My_data <- reactive({
         png(file, width=width*pixelratio, height=height*pixelratio,
             res=72*pixelratio)
       else if(input$filetype == "svg")
-          devSVGTips(file, width=width/50, height=height/50)
+        devSVGTips(file, width=width/50, height=height/50)
       else
         pdf(file,width = 22, height = 14)
       upset(data = My_data(), 

--- a/server.R
+++ b/server.R
@@ -446,7 +446,7 @@ My_data <- reactive({
         png(file, width=width*pixelratio, height=height*pixelratio,
             res=72*pixelratio)
       else if(input$filetype == "svg")
-          devSVGTips(file)
+          devSVGTips(file, width=width/50, height=height/50)
       else
         pdf(file,width = 22, height = 14)
       upset(data = My_data(), 


### PR DESCRIPTION
Sorry, a slight change to my previous pull request. By using a different SVG device, you get real text, rather than text as individual glyphs, which makes importing into Illustrators and the like much easier.